### PR TITLE
Possible fix of strange scroll behaviour

### DIFF
--- a/L2/Controls/ReactionsPicker.axaml
+++ b/L2/Controls/ReactionsPicker.axaml
@@ -15,9 +15,9 @@
           </ItemsPanelTemplate>
         </ItemsControl.ItemsPanel>
         <ItemsControl.ItemTemplate>
-          <DataTemplate x:DataType="mdl:Entity">
+          <DataTemplate x:DataType="mdl:ReactionEntity">
             <Button Classes="Tertiary" Loaded="Button_Loaded" Width="40" Height="40" Margin="2,0" Padding="0" CornerRadius="20" Command="{Binding Item5.Action}" CommandParameter="{Binding Item1}">
-              <Image controls:ImageLoader.SvgSource="{Binding Item2}" Width="36" Height="36"/>
+              <Image Source="{Binding Item2}" Width="36" Height="36"/>
             </Button>
           </DataTemplate>
         </ItemsControl.ItemTemplate>

--- a/L2/DataModels/TuplesAndGroupings.cs
+++ b/L2/DataModels/TuplesAndGroupings.cs
@@ -1,9 +1,12 @@
-﻿using ELOR.Laney.ViewModels;
+﻿using Avalonia.Media;
+using ELOR.Laney.ViewModels;
 using NeoSmart.Unicode;
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
+using System.Runtime.CompilerServices;
 
 namespace ELOR.Laney.DataModels {
     public class TwoStringTuple : Tuple<string, string> {
@@ -22,6 +25,35 @@ namespace ELOR.Laney.DataModels {
 
     public class Entity : Tuple<long, Uri, string, string, Command> {
         public Entity(long item1, Uri item2, string item3, string item4, Command item5) : base(item1, item2, item3, item4, item5) {}
+    }
+
+    public class ReactionEntity : INotifyPropertyChanged
+    {
+        public event PropertyChangedEventHandler? PropertyChanged;
+        protected void OnPropertyChanged([CallerMemberName] string propertyName = null)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+
+        public long Item1 { get; set; }
+        private IImage _item2;
+        public IImage Item2
+        {
+            get { return _item2; }
+            set { _item2 = value; OnPropertyChanged(); }
+        }
+        public string Item3 { get; set; }
+        public string Item4 { get; set; }
+        public Command Item5 { get; set; }
+
+        public ReactionEntity(long item1, IImage item2, string item3, string item4, Command item5)
+        {
+            Item1 = item1;
+            Item2 = item2;
+            Item3 = item3;
+            Item4 = item4;
+            Item5 = item5;
+        }
     }
 
     public class ReactionGroup : Tuple<int, int, List<Entity>> {

--- a/L2/Views/ChatView.axaml.cs
+++ b/L2/Views/ChatView.axaml.cs
@@ -278,11 +278,16 @@ namespace ELOR.Laney.Views {
             var msg = Chat.DisplayedMessages?.GetById(messageId);
             int index = Chat.DisplayedMessages.IndexOf(msg);
             Log.Information($"ScrollToMessage: cmid={messageId}; index={index}");
-            if (canTriggerLoadingMessages) {
+
+            // проверка, что мы хотим прокрутиться до последнего сообщения
+            // зачем? потому что, если последнее сообщение по размерам больше, чем 
+            // viewport, то будет показываться только начало этого сообщения
+            // а мы хотим самый низ - поэтому так
+            scrollToMessageIndex = index;
+            if (index != Chat.DisplayedMessages.Count - 1)
                 MessagesList.ScrollIntoView(scrollToMessageIndex);
-            } else {
-                scrollToMessageIndex = index;
-            }
+            else
+                MessagesList.Scroll.Offset = MessagesList.Scroll.Offset.WithY(MessagesList.Scroll.Extent.Height);
         }
 
         private void CheckFirstAndLastDisplayedMessages() {


### PR DESCRIPTION
When you scroll up some messages and click the button with arrow to go down - usually nothing happens or even throws you to a random message. 
I changed this behaviour and seems like it works properly. But! I don't know for what reason there was ```if (canTriggerLoadingMessages)``` and what it did. So possibly this PR should not be merged